### PR TITLE
Fix Typo in Description of sPMM Algorithm in become-a-woofi-broker.md

### DIFF
--- a/guides/become-a-woofi-broker.md
+++ b/guides/become-a-woofi-broker.md
@@ -2,7 +2,7 @@
 
 ### What are WOOFi brokers?
 
-WOOFi's bespoken sPMM algorithm provides deep liquidity and MEV proof trade execution on assets such as BTC, ETH, BNB, AVAX, FTM and predominant stablecoins on each blockchain. We aim to be the liquidity layer across DeFi, Web3 and GameFi spaces.
+WOOFi's bespoke sPMM algorithm provides deep liquidity and MEV proof trade execution on assets such as BTC, ETH, BNB, AVAX, FTM and predominant stablecoins on each blockchain. We aim to be the liquidity layer across DeFi, Web3 and GameFi spaces.
 
 WOOFi has the lowest swap fee in the market with only 2.5bps on each transaction, in which 0.02% is used to buy back WOO tokens and reward WOO onchain stakers. WOOFi brokers are the applications or sites that route trades to WOOFi smart contracts. A whitelisted broker is eligible to receive 0.5bps of each trade that is sent to WOOFi via the broker's application as rebates in the form of quote tokens i.e. stablecoins.
 


### PR DESCRIPTION
#### Description:  
This update corrects a typo in the description of WOOFi's sPMM algorithm in the `guides/become-a-woofi-broker.md` file. The original text incorrectly used the word **"bespoken"**, which does not fit the intended meaning in this context.  

The correct word is **"bespoke"**, meaning "custom-made" or "tailored," which accurately describes the nature of the sPMM algorithm.  

#### Why this matters:  
The typo may confuse readers or undermine the professionalism of the documentation, as "bespoken" is not standard English usage in this context. Fixing this ensures the text is clear, precise, and maintains the credibility of WOOFi's technical documentation.  

#### Changes:  
- Replaced **"bespoken"** with **"bespoke"** in the phrase:  
  > "WOOFi's bespoke sPMM algorithm..."  

This small but important change improves clarity and reflects the intended meaning.